### PR TITLE
Update composer-plugin-api version restriction.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "composer-plugin-api": "1.0.0",
+        "composer-plugin-api": "~1.0",
         "symfony/console": "~2.5",
         "symfony/filesystem": "~2.5"
     },
     "require-dev": {
         "composer/composer": "~1.0@dev",
-        "codeception/codeception": "dev-master"
+        "codeception/codeception": "~4.1@dev"
     }
 }


### PR DESCRIPTION
To prevent error:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for etki/opencart-core-installer ~0.1 -> satisfiable by etki/opencart-core-installer[0.1.0].
    - etki/opencart-core-installer 0.1.0 requires composer-plugin-api 1.0.0 -> no matching package found.
```